### PR TITLE
fix: prevent infinite recursion in setup_project.py (#22)

### DIFF
--- a/setup_project.py
+++ b/setup_project.py
@@ -236,6 +236,15 @@ def process_template_directory(src_dir: Path, dst_dir: Path, info: Dict[str, Any
         if item.is_file():
             rel_path = item.relative_to(src_dir)
 
+            # Skip the destination directory to prevent infinite recursion
+            try:
+                # Check if this file is within the destination directory
+                item.relative_to(dst_dir)
+                continue  # Skip files that are in the destination directory
+            except ValueError:
+                # File is not in destination directory, proceed
+                pass
+
             # Skip files based on configuration
             if any(skip in str(rel_path) for skip in skip_files):
                 continue


### PR DESCRIPTION
## Summary
- Fixed infinite recursion bug in `process_template_directory` function that caused "File name too long" errors
- Added destination directory exclusion logic to prevent recursive copying of newly created project directory
- Resolves issue #22 where setup would fail when project created within template directory

## Test plan
- [x] Verify setup_project.py compiles without syntax errors
- [ ] Test project creation in various scenarios to ensure fix works
- [ ] Verify existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)