### PR TITLE
Fix: Skip .git and cache directories during in-place setup (#47)

### DIFF
--- a/setup_project.py
+++ b/setup_project.py
@@ -723,14 +723,21 @@ def setup_in_place(project_dir: Path, info: Dict[str, Any]) -> None:
         cleanup_template_files(project_dir, info)
 
         # Copy all processed files from temp to current directory
-        # Skip setup_project.py to avoid overwriting the running script
+        # Skip setup_project.py and .git directory to avoid conflicts
         print("📋 Installing new project files...")
         for item in temp_path.rglob('*'):
             if item.is_file():
                 rel_path = item.relative_to(temp_path)
+                rel_path_str = str(rel_path)
 
                 # Skip setup_project.py since it's currently running
-                if str(rel_path) == 'setup_project.py':
+                if rel_path_str == 'setup_project.py':
+                    continue
+
+                # Skip .git directory - repository is already initialized when cloning from GitHub
+                # Also skip other VCS and cache directories that shouldn't be copied
+                skip_patterns = ['.git', '__pycache__', '.pytest_cache', '.mypy_cache', '.ruff_cache', '.nox']
+                if any(pattern in rel_path.parts for pattern in skip_patterns):
                     continue
 
                 dest_path = project_dir / rel_path


### PR DESCRIPTION
## Summary

Completes the fix for #47 - Resolves the remaining `FileNotFoundError` that occurs when cloning the template from GitHub.

This PR builds on PR #48 which fixed the cleanup order issue.

## Problem

After PR #48 was merged, users **still encounter the same error**. The actual root cause was not the cleanup order alone:

**When cloning from GitHub template:**
1. Repository already has an initialized `.git` folder with its own history
2. `process_template_directory()` copies everything including `.git` from project → temp
3. `setup_in_place()` tries to copy `.git` files from temp → project directory  
4. This attempts to **overwrite active git objects** that are locked/in-use by the running repository
5. `FileNotFoundError` occurs when `shutil.copy2()` tries to open git files for writing

## Solution

Skip `.git` and other VCS/cache directories when copying from temp back to project:
- `.git` - Repository is already initialized when cloning from GitHub
- `__pycache__`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.nox` - Python cache directories

These directories should never be copied during in-place setup as they are:
1. Either already present and in-use (`.git`)
2. Or will be regenerated as needed (cache directories)

## Changes Made

- [setup_project.py:737-741](https://github.com/ChadHattabaugh/pyProjectFactory/blob/bugfix/skip-git-directory-in-setup/setup_project.py#L737-L741) - Added skip logic for VCS and cache directories during file copy

## Testing

- ✅ Python syntax validation passed
- ⚠️ **Ready for manual testing**: Clone template from GitHub and run `setup_project.py` to verify complete fix

## Test Plan

1. Clone pyProjectFactory as a GitHub template (creates new repo with `.git` already initialized)
2. Run `python setup_project.py`
3. Verify setup completes **without FileNotFoundError**
4. Verify `.git` folder remains intact with new repository's history (not template's)
5. Verify all project files are properly set up

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>